### PR TITLE
Add a CLI for fetching results across years / disciplines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.purs*
 /.psa*
 /.spago
+.direnv

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
                     console
                     effect
                     affjax-node
+                    optparse
                     prelude
                   ];
 

--- a/scripts/format
+++ b/scripts/format
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-purs-tidy format-in-place '**/*.purs'
+purs-tidy format-in-place "src/**/*.purs"
+purs-tidy format-in-place "test/**/*.purs"

--- a/scripts/test-in-nix
+++ b/scripts/test-in-nix
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-purs-tidy check "{src,test}/**/*.purs"
+set -e
+
+purs-tidy check "src/**/*.purs"
+
+purs-tidy check "test/**/*.purs"
 
 npm install
 

--- a/src/Cli/Parser.purs
+++ b/src/Cli/Parser.purs
@@ -1,0 +1,99 @@
+module Cli.Parser where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Generic.Rep (class Generic)
+import Data.Show.Generic (genericShow)
+import Options.Applicative
+  ( Parser
+  , ParserInfo
+  , ReadM
+  , eitherReader
+  , fullDesc
+  , header
+  , help
+  , helper
+  , info
+  , int
+  , long
+  , option
+  , progDesc
+  , short
+  , strOption
+  , value
+  , (<**>)
+  )
+import Web.IFSC.Client (BaseUrl(..))
+import Web.IFSC.Model (Discipline(..), SeasonName(..))
+
+newtype StartSeason = StartSeason SeasonName
+
+derive newtype instance Eq StartSeason
+
+derive newtype instance Show StartSeason
+
+newtype EndSeason = EndSeason SeasonName
+
+derive newtype instance Eq EndSeason
+
+derive newtype instance Show EndSeason
+
+data FetchParams = FetchParams StartSeason EndSeason Discipline BaseUrl
+
+derive instance Generic FetchParams _
+
+derive instance Eq FetchParams
+
+instance Show FetchParams where
+  show = genericShow
+
+startSeason :: Parser StartSeason
+startSeason = StartSeason <<< SeasonName <$> option int
+  ( long "from-year"
+      <> short 'f'
+      <> help "First year to consider results from"
+      <> value 2010
+  )
+
+endSeason :: Parser EndSeason
+endSeason = EndSeason <<< SeasonName <$> option int
+  ( long "to-year"
+      <> short 't'
+      <> help "Last year to consider results from"
+      <> value 2022
+  )
+
+disciplineReader :: ReadM Discipline
+disciplineReader = eitherReader $ case _ of
+  "boulder" -> Right Boulder
+  "lead" -> Right Lead
+  "boulder&lead" -> Right BoulderAndLead
+  "speed" -> Right Speed
+  s -> Left $ "Invalid discipline: " <> s
+
+discipline :: Parser Discipline
+discipline = option disciplineReader
+  ( long "discipline"
+      <> short 'd'
+      <> help "Which discipline to assemble results for. Options are boulder, lead, boulder&lead, and speed"
+      <> value Boulder
+  )
+
+baseUrl :: Parser BaseUrl
+baseUrl = BaseUrl <$> strOption
+  ( long "base-url"
+      <> short 'u'
+      <> help "API root to run requests against"
+      <> value "http://localhost:8080"
+  )
+
+fetchParser :: Parser FetchParams
+fetchParser = FetchParams <$> startSeason <*> endSeason <*> discipline <*> baseUrl
+
+progOpts :: ParserInfo FetchParams
+progOpts = info (fetchParser <**> helper)
+  ( fullDesc
+      <> progDesc "Fetch IFSC results for a discipline in a range of years"
+      <> header "ifsc-stats - a CLI client for the undocumented IFSC API"
+  )

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -1,8 +1,26 @@
 module Main where
 
 import Prelude
+
+import Affjax (printError)
+import Cli.Parser (EndSeason(..), FetchParams(..), StartSeason(..), progOpts)
+import Control.Monad.Except (runExceptT)
+import Control.Monad.Reader (runReaderT)
+import Data.Argonaut (stringify)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
 import Effect (Effect)
-import Effect.Console (log)
+import Effect.Aff (launchAff_)
+import Effect.Class.Console (log)
+import Options.Applicative (execParser)
+import Options.Applicative.Internal.Utils (unLines)
+import Web.IFSC.Client (FetchError(..), fullSeasons)
+import Web.IFSC.Model (SeasonName(..))
 
 main :: Effect Unit
-main = log "❄"
+main = do
+  (FetchParams (StartSeason (SeasonName start)) (EndSeason (SeasonName end)) discipline baseUrl) <- execParser progOpts
+  launchAff_ $ (runExceptT $ runReaderT (fullSeasons discipline (Just start) (Just end)) baseUrl) >>= case _ of
+    Right _ -> log "fetch successful woohoo"
+    Left (FetchError e url body) -> log $ unLines [ "=======", "At url: " <> url, printError e, "----", stringify body ]
+

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -7,12 +7,12 @@ import Cli.Parser (EndSeason(..), FetchParams(..), StartSeason(..), progOpts)
 import Control.Monad.Except (runExceptT)
 import Control.Monad.Reader (runReaderT)
 import Data.Argonaut (stringify)
-import Data.Array (intersperse)
 import Data.Either (Either(..))
+import Data.Foldable (intercalate)
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Aff (launchAff_)
-import Effect.Class.Console (log, logShow)
+import Effect.Class.Console (log)
 import Options.Applicative (execParser)
 import Web.IFSC.Client (FetchError(..), fullSeasons)
 import Web.IFSC.Model (SeasonName(..))
@@ -22,5 +22,7 @@ main = do
   (FetchParams (StartSeason (SeasonName start)) (EndSeason (SeasonName end)) discipline baseUrl) <- execParser progOpts
   launchAff_ $ (runExceptT $ runReaderT (fullSeasons discipline (Just start) (Just end)) baseUrl) >>= case _ of
     Right _ -> log "fetch successful"
-    Left (FetchError e url body) -> logShow $ intersperse "\n" [ "=======", "At url: " <> url, printError e, "----", stringify body ]
+    Left (FetchError e url body) ->
+      log $
+        intercalate "\n" [ "=======", "At url: " <> url, printError e, "----", stringify body ]
 

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -7,13 +7,13 @@ import Cli.Parser (EndSeason(..), FetchParams(..), StartSeason(..), progOpts)
 import Control.Monad.Except (runExceptT)
 import Control.Monad.Reader (runReaderT)
 import Data.Argonaut (stringify)
+import Data.Array (intersperse)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Aff (launchAff_)
-import Effect.Class.Console (log)
+import Effect.Class.Console (log, logShow)
 import Options.Applicative (execParser)
-import Options.Applicative.Internal.Utils (unLines)
 import Web.IFSC.Client (FetchError(..), fullSeasons)
 import Web.IFSC.Model (SeasonName(..))
 
@@ -21,6 +21,6 @@ main :: Effect Unit
 main = do
   (FetchParams (StartSeason (SeasonName start)) (EndSeason (SeasonName end)) discipline baseUrl) <- execParser progOpts
   launchAff_ $ (runExceptT $ runReaderT (fullSeasons discipline (Just start) (Just end)) baseUrl) >>= case _ of
-    Right _ -> log "fetch successful woohoo"
-    Left (FetchError e url body) -> log $ unLines [ "=======", "At url: " <> url, printError e, "----", stringify body ]
+    Right _ -> log "fetch successful"
+    Left (FetchError e url body) -> logShow $ intersperse "\n" [ "=======", "At url: " <> url, printError e, "----", stringify body ]
 

--- a/src/Web/IFSC/Client.purs
+++ b/src/Web/IFSC/Client.purs
@@ -10,7 +10,7 @@ import Control.Monad.Except (ExceptT(..), except)
 import Control.Monad.Reader (ReaderT, lift)
 import Control.Monad.Reader.Class (ask)
 import Data.Argonaut (class DecodeJson, Json, JsonDecodeError, decodeJson, encodeJson, printJsonDecodeError)
-import Data.Array (filter, intersperse, last)
+import Data.Array (filter, last)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..), note)
 import Data.Foldable (fold)
@@ -149,13 +149,7 @@ fullSeasons searchDiscipline fromYear toYear =
         )
         seasonsInRange
       let allEvents = join <<< join $ seasonLeagueEvents
-      log $ "All events:\n" <>
-        ( let
-            allEventNames = _.event <$> allEvents
-            eventNamesWithNewLines = intersperse "\n" allEventNames
-          in
-            show (fold eventNamesWithNewLines)
-        )
+      log $ "All events:\n" <> show (_.event <$> allEvents)
       eventIds <- lift <<< except $ traverse getEventId allEvents
       eventPartialResultsArrArr <- traverse getEventResults eventIds
       let

--- a/src/Web/IFSC/Client.purs
+++ b/src/Web/IFSC/Client.purs
@@ -5,10 +5,11 @@ import Prelude
 import Affjax (Error(..))
 import Affjax.Node (get)
 import Affjax.ResponseFormat (json)
+import Affjax.ResponseHeader (ResponseHeader)
 import Control.Monad.Except (ExceptT(..), except)
 import Control.Monad.Reader (ReaderT, lift)
 import Control.Monad.Reader.Class (ask)
-import Data.Argonaut (class DecodeJson, Json, JsonDecodeError, decodeJson, printJsonDecodeError)
+import Data.Argonaut (class DecodeJson, Json, JsonDecodeError, decodeJson, encodeJson, printJsonDecodeError)
 import Data.Array (filter, last)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..), note)
@@ -27,25 +28,38 @@ import Web.IFSC.Model
   , LandingPage
   , LandingPageSeason(..)
   , LeagueId(..)
+  , LeagueName(..)
   , ResultUrl(..)
   , SeasonLeagueResults
   , SeasonName(..)
   , disciplineCategoryResults
   )
 
+data FetchError = FetchError Error String Json
+
 newtype BaseUrl = BaseUrl String
+
+derive newtype instance Eq BaseUrl
+
+derive newtype instance Show BaseUrl
 
 type WithConfig :: forall k. (k -> Type) -> k -> Type
 type WithConfig m a = ReaderT BaseUrl m a
 
-getEventId :: Event -> Either Error EventId
+getEventId :: Event -> Either FetchError EventId
 getEventId { url } =
   let
     segments = split (Pattern "/") url
-    lastSegment = note (RequestContentError "Url segment was empty") $ last segments
+    lastSegment =
+      note
+        ( FetchError (RequestContentError "Url segment was empty") url (encodeJson {})
+        ) $
+        last segments
     eventId = lastSegment >>=
       ( \s ->
-          note (RequestContentError $ "Could not read last url segment to an int in url: " <> url) $
+          note
+            ( FetchError (RequestContentError $ "Could not read last url segment to an int in url: " <> url) url (encodeJson {})
+            ) $
             EventId <$> fromString s
       )
   in
@@ -61,7 +75,7 @@ getDecodedBody
   :: forall a
    . forall r
    . DecodeJson a
-  => Either Error ({ body :: Json | r })
+  => Either Error ({ body :: Json, headers :: Array ResponseHeader | r })
   -> Either Error a
 getDecodedBody = case _ of
   Right a ->
@@ -71,27 +85,34 @@ getDecodedBody = case _ of
     )
   Left e -> Left e
 
-getJsonUrl :: forall a. DecodeJson a => String -> WithConfig (ExceptT Error Aff) a
-getJsonUrl urlPart = do
-  BaseUrl base <- ask
-  lift <<< ExceptT $ getDecodedBody <$> get json (base <> urlPart)
+getJsonUrl :: forall a. DecodeJson a => String -> WithConfig (ExceptT FetchError Aff) a
+getJsonUrl urlPart =
+  do
+    BaseUrl base <- ask
+    let fullUrl = base <> urlPart
+    lift <<< ExceptT $
+      ( case _ of
+          response@(Right { body }) ->
+            lmap (\e -> FetchError e fullUrl body) $ getDecodedBody response
+          Left e -> Left $ FetchError e fullUrl (encodeJson {})
+      ) <$> get json fullUrl
 
-getLandingPage :: WithConfig (ExceptT Error Aff) LandingPage
+getLandingPage :: WithConfig (ExceptT FetchError Aff) LandingPage
 getLandingPage = getJsonUrl "/results-api.php?api=index"
 
-getSeasonLeagueResults :: LeagueId -> WithConfig (ExceptT Error Aff) SeasonLeagueResults
+getSeasonLeagueResults :: LeagueId -> WithConfig (ExceptT FetchError Aff) SeasonLeagueResults
 getSeasonLeagueResults (LeagueId league) =
-  getJsonUrl $ "/results-api.php?api=season_league_results&league=" <> show league
+  getJsonUrl $ "/results-api.php?api=season_leagues_results&league=" <> show league
 
-getEventResults :: EventId -> WithConfig (ExceptT Error Aff) (Array EventResult)
+getEventResults :: EventId -> WithConfig (ExceptT FetchError Aff) (Array EventResult)
 getEventResults eventId =
   disciplineCategoryResults <$> (getJsonUrl $ "/results-api.php?api=event_results&event_id=" <> show eventId)
 
-getEventFullResults :: ResultUrl -> WithConfig (ExceptT Error Aff) EventFullResults
+getEventFullResults :: ResultUrl -> WithConfig (ExceptT FetchError Aff) EventFullResults
 getEventFullResults (ResultUrl queryParam) =
   getJsonUrl $ "/results-api.php?api=event_full_results&result_url=" <> queryParam
 
-fullSeasons :: Discipline -> Maybe Int -> Maybe Int -> WithConfig (ExceptT Error Aff) (Array EventFullResults)
+fullSeasons :: Discipline -> Maybe Int -> Maybe Int -> WithConfig (ExceptT FetchError Aff) (Array EventFullResults)
 fullSeasons searchDiscipline fromYear toYear =
   let
     inRange =
@@ -109,7 +130,13 @@ fullSeasons searchDiscipline fromYear toYear =
       seasonLeagueEvents <- traverse
         ( \(LandingPageSeason { leagues }) ->
             let
-              leagueIds = _.id <$> leagues
+              leagueIds = _.id <$>
+                ( filter
+                    ( \league ->
+                        league.name == LeagueName "World Cups and World Championships"
+                    )
+                    leagues
+                )
             in
               -- for each league, get league results
               (_.events <$> _) <$> traverse getSeasonLeagueResults leagueIds
@@ -127,5 +154,5 @@ fullSeasons searchDiscipline fromYear toYear =
       allFullResults <- traverse getEventFullResults ((\(EventResult { fullResultsUrl }) -> fullResultsUrl) <$> eventPartialResults)
       pure allFullResults
 
-allFullSeasons :: Discipline -> ReaderT BaseUrl (ExceptT Error Aff) (Array EventFullResults)
+allFullSeasons :: Discipline -> ReaderT BaseUrl (ExceptT FetchError Aff) (Array EventFullResults)
 allFullSeasons discipline = fullSeasons discipline Nothing Nothing

--- a/src/Web/IFSC/Client.purs
+++ b/src/Web/IFSC/Client.purs
@@ -13,7 +13,7 @@ import Data.Argonaut (class DecodeJson, Json, JsonDecodeError, decodeJson, encod
 import Data.Array (filter, last)
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..), note)
-import Data.Foldable (fold)
+import Data.Foldable (fold, intercalate)
 import Data.Int (fromString)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (Pattern(..), split)
@@ -149,7 +149,11 @@ fullSeasons searchDiscipline fromYear toYear =
         )
         seasonsInRange
       let allEvents = join <<< join $ seasonLeagueEvents
-      log $ "All events:\n" <> show (_.event <$> allEvents)
+      log $ "All events:\n" <>
+        let
+          allEventNames = _.event <$> allEvents
+        in
+          intercalate "\n" allEventNames
       eventIds <- lift <<< except $ traverse getEventId allEvents
       eventPartialResultsArrArr <- traverse getEventResults eventIds
       let

--- a/src/Web/IFSC/Model.purs
+++ b/src/Web/IFSC/Model.purs
@@ -199,7 +199,8 @@ instance DecodeJson Round where
     Just jObject -> do
       roundName <- jObject .: "round_name"
       score <- jObject .: "score"
-      ascents <- jObject .: "ascents"
+      speedResults <- jObject .: "speed_elimination_stages"
+      ascents <- speedResults .: "ascents"
       pure $ Round { roundName, score, ascents }
     Nothing -> Left $ UnexpectedValue json
 

--- a/src/Web/IFSC/Model.purs
+++ b/src/Web/IFSC/Model.purs
@@ -237,8 +237,8 @@ derive newtype instance Show ScoreString
 newtype Ascent = Ascent
   { top :: Boolean
   , zone :: Boolean
-  , topTries :: Int
-  , zoneTries :: Int
+  , topTries :: Maybe Int
+  , zoneTries :: Maybe Int
   }
 
 derive newtype instance Show Ascent

--- a/src/Web/IFSC/Model.purs
+++ b/src/Web/IFSC/Model.purs
@@ -60,6 +60,8 @@ newtype SeasonName = SeasonName Int
 
 derive newtype instance DecodeJson SeasonName
 
+derive newtype instance Eq SeasonName
+
 derive newtype instance Show SeasonName
 
 data Discipline
@@ -93,6 +95,8 @@ type League =
 newtype LeagueName = LeagueName String
 
 derive newtype instance DecodeJson LeagueName
+
+derive newtype instance Eq LeagueName
 
 derive newtype instance Show LeagueName
 

--- a/test/Test/Cli/ParserSpec.purs
+++ b/test/Test/Cli/ParserSpec.purs
@@ -1,0 +1,41 @@
+module Test.Cli.ParserSpec where
+
+import Prelude
+
+import Cli.Parser (EndSeason(..), FetchParams(..), StartSeason(..), progOpts)
+import Data.Maybe (Maybe(..))
+import Effect.Aff (Aff)
+import Options.Applicative (defaultPrefs, execParserPure, getParseResult)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+import Web.IFSC.Client (BaseUrl(..))
+import Web.IFSC.Model (Discipline(..), SeasonName(..))
+
+spec :: Spec Unit
+spec =
+  describe "Command parser" $ do
+    it "with all long options" $
+      parseTest
+        [ "--from-year", "2005", "--to-year", "2010", "--discipline", "lead" ]
+        (FetchParams (StartSeason $ SeasonName 2005) (EndSeason $ SeasonName 2010) Lead defaultBaseUrl)
+    it "with all short options" $
+      parseTest
+        [ "-f", "2005", "-t", "2010", "-d", "lead" ]
+        (FetchParams (StartSeason $ SeasonName 2005) (EndSeason $ SeasonName 2010) Lead defaultBaseUrl)
+    it "with missing discipline" $
+      parseTest [ "-f", "2005", "-t", "2013" ]
+        (FetchParams (StartSeason $ SeasonName 2005) (EndSeason $ SeasonName 2013) Boulder defaultBaseUrl)
+    it "with missing start year" $
+      parseTest [ "-t", "2013", "-d", "speed" ]
+        (FetchParams (StartSeason $ SeasonName 2010) (EndSeason $ SeasonName 2013) Speed defaultBaseUrl)
+    it "with missing end year" $
+      parseTest [ "-f", "2001", "-d", "boulder&lead" ]
+        (FetchParams (StartSeason $ SeasonName 2001) (EndSeason $ SeasonName 2022) BoulderAndLead defaultBaseUrl)
+
+defaultBaseUrl :: BaseUrl
+defaultBaseUrl = BaseUrl "http://localhost:8080"
+
+parseTest :: Array String -> FetchParams -> Aff Unit
+parseTest args expectation =
+  getParseResult (execParserPure defaultPrefs progOpts args)
+    `shouldEqual` Just expectation

--- a/wiremock-mappings/eventFullResultsMen.json
+++ b/wiremock-mappings/eventFullResultsMen.json
@@ -1,1228 +1,1264 @@
 {
-    "request": {
-        "method": "GET",
-        "url": "/results-api.php?api=event_full_results&result_url=/api/v1/events/9246/result/5"
+  "request": {
+    "method": "GET",
+    "url": "/results-api.php?api=event_full_results&result_url=/api/v1/events/9246/result/5"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
     },
-    "response": {
-        "status": 200,
-        "headers": {
-            "Content-Type": "application/json"
+    "jsonBody": {
+      "ranking": [
+        {
+          "athlete_id": 2272,
+          "rank": 1,
+          "firstname": "Kokoro",
+          "lastname": "FUJII",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "JPN",
+          "federation_id": 25,
+          "rounds": [
+            {
+              "category_round_id": 6848,
+              "round_name": "Qualification",
+              "score": "3T5z 9 9",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7614,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:01:09 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7615,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:11:41 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7616,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:24:41 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7617,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 4,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:34:51 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7618,
+                    "route_name": "5",
+                    "top": false,
+                    "top_tries": 5,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:45:59 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7423,
+              "round_name": "Semi-final",
+              "score": "3T3z 5 5",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7624,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:49:21 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7625,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:01:15 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7626,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 10,
+                    "zone": false,
+                    "zone_tries": 10,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:12:45 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7627,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:19:47 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7425,
+              "round_name": "Final",
+              "score": "4T4z 11 4",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7632,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:47 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7633,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:51 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7634,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:53 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7635,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:58 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
         },
-        "jsonBody": {
-            "ranking": [
-                {
-                    "athlete_id": 2272,
-                    "rank": 1,
-                    "firstname": "Kokoro",
-                    "lastname": "FUJII",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "JPN",
-                    "federation_id": 25,
-                    "rounds": [
-                        {
-                            "category_round_id": 6848,
-                            "round_name": "Qualification",
-                            "score": "3T5z 9 9",
-                            "ascents": [
-                                {
-                                    "route_id": 7614,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:01:09 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7615,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:11:41 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7616,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:24:41 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7617,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 4,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:34:51 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7618,
-                                    "route_name": "5",
-                                    "top": false,
-                                    "top_tries": 5,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:45:59 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7423,
-                            "round_name": "Semi-final",
-                            "score": "3T3z 5 5",
-                            "ascents": [
-                                {
-                                    "route_id": 7624,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:49:21 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7625,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:01:15 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7626,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 10,
-                                    "zone": false,
-                                    "zone_tries": 10,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:12:45 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7627,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:19:47 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7425,
-                            "round_name": "Final",
-                            "score": "4T4z 11 4",
-                            "ascents": [
-                                {
-                                    "route_id": 7632,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:47 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7633,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:51 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7634,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:53 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7635,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:58 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "athlete_id": 2276,
-                    "rank": 2,
-                    "firstname": "Tomoa",
-                    "lastname": "NARASAKI",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "JPN",
-                    "federation_id": 25,
-                    "rounds": [
-                        {
-                            "category_round_id": 6848,
-                            "round_name": "Qualification",
-                            "score": "2T4z 2 11",
-                            "ascents": [
-                                {
-                                    "route_id": 7614,
-                                    "route_name": "1",
-                                    "top": false,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 4,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:01:10 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7615,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:11:41 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7616,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:24:41 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7617,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 8,
-                                    "zone": false,
-                                    "zone_tries": 8,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:34:51 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7618,
-                                    "route_name": "5",
-                                    "top": false,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 5,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:45:59 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7423,
-                            "round_name": "Semi-final",
-                            "score": "3T4z 10 8",
-                            "ascents": [
-                                {
-                                    "route_id": 7624,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 4,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:49:15 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7625,
-                                    "route_name": "2",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:01:11 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7626,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:12:46 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7627,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:19:40 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7425,
-                            "round_name": "Final",
-                            "score": "4T4z 12 8",
-                            "ascents": [
-                                {
-                                    "route_id": 7632,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:48 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7633,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:52 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7634,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:52 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7635,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 4,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:58 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "athlete_id": 2309,
-                    "rank": 3,
-                    "firstname": "Yoshiyuki",
-                    "lastname": "OGATA",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "JPN",
-                    "federation_id": 25,
-                    "rounds": [
-                        {
-                            "category_round_id": 6848,
-                            "round_name": "Qualification",
-                            "score": "2T5z 3 8",
-                            "ascents": [
-                                {
-                                    "route_id": 7614,
-                                    "route_name": "1",
-                                    "top": false,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:01:11 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7615,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:11:42 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7616,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:24:44 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7617,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:34:51 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7618,
-                                    "route_name": "5",
-                                    "top": false,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:46:00 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7423,
-                            "round_name": "Semi-final",
-                            "score": "2T4z 6 4",
-                            "ascents": [
-                                {
-                                    "route_id": 7624,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:49:19 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7625,
-                                    "route_name": "2",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:01:12 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7626,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 5,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:12:40 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7627,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 5,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:19:42 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7425,
-                            "round_name": "Final",
-                            "score": "3T4z 6 7",
-                            "ascents": [
-                                {
-                                    "route_id": 7632,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:45 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7633,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:49 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7634,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:55 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7635,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:56 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "athlete_id": 547,
-                    "rank": 4,
-                    "firstname": "Paul",
-                    "lastname": "JENFT",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "FRA",
-                    "federation_id": 10,
-                    "rounds": [
-                        {
-                            "category_round_id": 6848,
-                            "round_name": "Qualification",
-                            "score": "3T5z 10 17",
-                            "ascents": [
-                                {
-                                    "route_id": 7614,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 6,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:01:31 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7615,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:11:57 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7616,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:24:58 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7617,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:34:57 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7618,
-                                    "route_name": "5",
-                                    "top": false,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 6,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:46:06 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7423,
-                            "round_name": "Semi-final",
-                            "score": "2T4z 4 6",
-                            "ascents": [
-                                {
-                                    "route_id": 7624,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:49:21 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7625,
-                                    "route_name": "2",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:01:17 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7626,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:12:44 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7627,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:19:45 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7425,
-                            "round_name": "Final",
-                            "score": "2T4z 4 11",
-                            "ascents": [
-                                {
-                                    "route_id": 7632,
-                                    "route_name": "1",
-                                    "top": false,
-                                    "top_tries": 8,
-                                    "zone": true,
-                                    "zone_tries": 5,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:46 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7633,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:50 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7634,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:54 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7635,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:57 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "athlete_id": 2307,
-                    "rank": 5,
-                    "firstname": "Meichi",
-                    "lastname": "NARASAKI",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "JPN",
-                    "federation_id": 25,
-                    "rounds": [
-                        {
-                            "category_round_id": 6848,
-                            "round_name": "Qualification",
-                            "score": "2T5z 4 9",
-                            "ascents": [
-                                {
-                                    "route_id": 7614,
-                                    "route_name": "1",
-                                    "top": false,
-                                    "top_tries": 5,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:01:56 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7615,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:12:09 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7616,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:25:11 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7617,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:35:16 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7618,
-                                    "route_name": "5",
-                                    "top": false,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:46:24 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7423,
-                            "round_name": "Semi-final",
-                            "score": "2T4z 2 9",
-                            "ascents": [
-                                {
-                                    "route_id": 7624,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:49:16 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7625,
-                                    "route_name": "2",
-                                    "top": false,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:01:14 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7626,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 7,
-                                    "zone": true,
-                                    "zone_tries": 6,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:12:40 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7627,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:19:41 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7425,
-                            "round_name": "Final",
-                            "score": "2T3z 3 6",
-                            "ascents": [
-                                {
-                                    "route_id": 7632,
-                                    "route_name": "1",
-                                    "top": false,
-                                    "top_tries": 10,
-                                    "zone": false,
-                                    "zone_tries": 10,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:47 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7633,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:50 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7634,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:53 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7635,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:58 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "athlete_id": 2334,
-                    "rank": 6,
-                    "firstname": "Keita",
-                    "lastname": "DOHI",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "JPN",
-                    "federation_id": 25,
-                    "rounds": [
-                        {
-                            "category_round_id": 6848,
-                            "round_name": "Qualification",
-                            "score": "3T4z 7 6",
-                            "ascents": [
-                                {
-                                    "route_id": 7614,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:01:34 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7615,
-                                    "route_name": "2",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:11:57 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7616,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:24:51 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7617,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:35:12 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7618,
-                                    "route_name": "5",
-                                    "top": false,
-                                    "top_tries": 6,
-                                    "zone": false,
-                                    "zone_tries": 6,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 12:46:07 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7423,
-                            "round_name": "Semi-final",
-                            "score": "2T4z 5 9",
-                            "ascents": [
-                                {
-                                    "route_id": 7624,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:49:20 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7625,
-                                    "route_name": "2",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:01:15 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7626,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:12:43 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7627,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:19:45 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7425,
-                            "round_name": "Final",
-                            "score": "1T4z 2 14",
-                            "ascents": [
-                                {
-                                    "route_id": 7632,
-                                    "route_name": "1",
-                                    "top": false,
-                                    "top_tries": 9,
-                                    "zone": true,
-                                    "zone_tries": 9,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:46 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7633,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:49 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7634,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:54 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7635,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 11:48:56 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+        {
+          "athlete_id": 2276,
+          "rank": 2,
+          "firstname": "Tomoa",
+          "lastname": "NARASAKI",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "JPN",
+          "federation_id": 25,
+          "rounds": [
+            {
+              "category_round_id": 6848,
+              "round_name": "Qualification",
+              "score": "2T4z 2 11",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7614,
+                    "route_name": "1",
+                    "top": false,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 4,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:01:10 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7615,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:11:41 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7616,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:24:41 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7617,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 8,
+                    "zone": false,
+                    "zone_tries": 8,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:34:51 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7618,
+                    "route_name": "5",
+                    "top": false,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 5,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:45:59 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7423,
+              "round_name": "Semi-final",
+              "score": "3T4z 10 8",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7624,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 4,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:49:15 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7625,
+                    "route_name": "2",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:01:11 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7626,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:12:46 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7627,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:19:40 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7425,
+              "round_name": "Final",
+              "score": "4T4z 12 8",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7632,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:48 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7633,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:52 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7634,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:52 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7635,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 4,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:58 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "athlete_id": 2309,
+          "rank": 3,
+          "firstname": "Yoshiyuki",
+          "lastname": "OGATA",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "JPN",
+          "federation_id": 25,
+          "rounds": [
+            {
+              "category_round_id": 6848,
+              "round_name": "Qualification",
+              "score": "2T5z 3 8",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7614,
+                    "route_name": "1",
+                    "top": false,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:01:11 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7615,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:11:42 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7616,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:24:44 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7617,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:34:51 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7618,
+                    "route_name": "5",
+                    "top": false,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:46:00 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7423,
+              "round_name": "Semi-final",
+              "score": "2T4z 6 4",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7624,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:49:19 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7625,
+                    "route_name": "2",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:01:12 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7626,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 5,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:12:40 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7627,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 5,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:19:42 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7425,
+              "round_name": "Final",
+              "score": "3T4z 6 7",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7632,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:45 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7633,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:49 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7634,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:55 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7635,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:56 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "athlete_id": 547,
+          "rank": 4,
+          "firstname": "Paul",
+          "lastname": "JENFT",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "FRA",
+          "federation_id": 10,
+          "rounds": [
+            {
+              "category_round_id": 6848,
+              "round_name": "Qualification",
+              "score": "3T5z 10 17",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7614,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 6,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:01:31 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7615,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:11:57 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7616,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:24:58 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7617,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:34:57 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7618,
+                    "route_name": "5",
+                    "top": false,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 6,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:46:06 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7423,
+              "round_name": "Semi-final",
+              "score": "2T4z 4 6",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7624,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:49:21 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7625,
+                    "route_name": "2",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:01:17 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7626,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:12:44 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7627,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:19:45 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7425,
+              "round_name": "Final",
+              "score": "2T4z 4 11",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7632,
+                    "route_name": "1",
+                    "top": false,
+                    "top_tries": 8,
+                    "zone": true,
+                    "zone_tries": 5,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:46 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7633,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:50 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7634,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:54 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7635,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:57 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "athlete_id": 2307,
+          "rank": 5,
+          "firstname": "Meichi",
+          "lastname": "NARASAKI",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "JPN",
+          "federation_id": 25,
+          "rounds": [
+            {
+              "category_round_id": 6848,
+              "round_name": "Qualification",
+              "score": "2T5z 4 9",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7614,
+                    "route_name": "1",
+                    "top": false,
+                    "top_tries": 5,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:01:56 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7615,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:12:09 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7616,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:25:11 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7617,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:35:16 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7618,
+                    "route_name": "5",
+                    "top": false,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:46:24 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7423,
+              "round_name": "Semi-final",
+              "score": "2T4z 2 9",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7624,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:49:16 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7625,
+                    "route_name": "2",
+                    "top": false,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:01:14 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7626,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 7,
+                    "zone": true,
+                    "zone_tries": 6,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:12:40 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7627,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:19:41 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7425,
+              "round_name": "Final",
+              "score": "2T3z 3 6",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7632,
+                    "route_name": "1",
+                    "top": false,
+                    "top_tries": 10,
+                    "zone": false,
+                    "zone_tries": 10,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:47 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7633,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:50 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7634,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:53 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7635,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:58 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "athlete_id": 2334,
+          "rank": 6,
+          "firstname": "Keita",
+          "lastname": "DOHI",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "JPN",
+          "federation_id": 25,
+          "rounds": [
+            {
+              "category_round_id": 6848,
+              "round_name": "Qualification",
+              "score": "3T4z 7 6",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7614,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:01:34 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7615,
+                    "route_name": "2",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:11:57 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7616,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:24:51 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7617,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:35:12 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7618,
+                    "route_name": "5",
+                    "top": false,
+                    "top_tries": 6,
+                    "zone": false,
+                    "zone_tries": 6,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 12:46:07 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7423,
+              "round_name": "Semi-final",
+              "score": "2T4z 5 9",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7624,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:49:20 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7625,
+                    "route_name": "2",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:01:15 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7626,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:12:43 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7627,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:19:45 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7425,
+              "round_name": "Final",
+              "score": "1T4z 2 14",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7632,
+                    "route_name": "1",
+                    "top": false,
+                    "top_tries": 9,
+                    "zone": true,
+                    "zone_tries": 9,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:46 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7633,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:49 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7634,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:54 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7635,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 11:48:56 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
         }
+      ]
     }
+  }
 }

--- a/wiremock-mappings/eventFullResultsWomen.json
+++ b/wiremock-mappings/eventFullResultsWomen.json
@@ -1,1228 +1,1264 @@
 {
-    "request": {
-        "method": "GET",
-        "url": "/results-api.php?api=event_full_results&result_url=/api/v1/events/9246/result/12"
+  "request": {
+    "method": "GET",
+    "url": "/results-api.php?api=event_full_results&result_url=/api/v1/events/9246/result/12"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
     },
-    "response": {
-        "status": 200,
-        "headers": {
-            "Content-Type": "application/json"
+    "jsonBody": {
+      "ranking": [
+        {
+          "athlete_id": 1803,
+          "rank": 1,
+          "firstname": "Natalia",
+          "lastname": "GROSSMAN",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "USA",
+          "federation_id": 20,
+          "rounds": [
+            {
+              "category_round_id": 6849,
+              "round_name": "Qualification",
+              "score": "5T5z 6 5",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7619,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:34:51 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7620,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:00 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7621,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:07 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7622,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:14 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7623,
+                    "route_name": "5",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:07 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7424,
+              "round_name": "Semi-final",
+              "score": "4T4z 10 10",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7628,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:51:15 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7629,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 6,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:57:41 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7630,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:08:16 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7631,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:20:14 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7426,
+              "round_name": "Final",
+              "score": "4T4z 7 5",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7636,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:18 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7637,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:34 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7638,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:07 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7639,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:41 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
         },
-        "jsonBody": {
-            "ranking": [
-                {
-                    "athlete_id": 1803,
-                    "rank": 1,
-                    "firstname": "Natalia",
-                    "lastname": "GROSSMAN",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "USA",
-                    "federation_id": 20,
-                    "rounds": [
-                        {
-                            "category_round_id": 6849,
-                            "round_name": "Qualification",
-                            "score": "5T5z 6 5",
-                            "ascents": [
-                                {
-                                    "route_id": 7619,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:34:51 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7620,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:00 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7621,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:07 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7622,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:14 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7623,
-                                    "route_name": "5",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:07 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7424,
-                            "round_name": "Semi-final",
-                            "score": "4T4z 10 10",
-                            "ascents": [
-                                {
-                                    "route_id": 7628,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:51:15 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7629,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 6,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:57:41 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7630,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:08:16 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7631,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:20:14 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7426,
-                            "round_name": "Final",
-                            "score": "4T4z 7 5",
-                            "ascents": [
-                                {
-                                    "route_id": 7636,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:18 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7637,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:34 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7638,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:07 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7639,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:41 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "athlete_id": 11462,
-                    "rank": 2,
-                    "firstname": "Oriane",
-                    "lastname": "BERTONE",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "FRA",
-                    "federation_id": 10,
-                    "rounds": [
-                        {
-                            "category_round_id": 6849,
-                            "round_name": "Qualification",
-                            "score": "4T5z 10 7",
-                            "ascents": [
-                                {
-                                    "route_id": 7619,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:35:06 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7620,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:35:56 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7621,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:08 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7622,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:38:40 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7623,
-                                    "route_name": "5",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:07 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7424,
-                            "round_name": "Semi-final",
-                            "score": "3T3z 5 5",
-                            "ascents": [
-                                {
-                                    "route_id": 7628,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:51:13 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7629,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:57:40 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7630,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 6,
-                                    "zone": false,
-                                    "zone_tries": 6,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:08:14 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7631,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:20:11 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7426,
-                            "round_name": "Final",
-                            "score": "3T4z 5 5",
-                            "ascents": [
-                                {
-                                    "route_id": 7636,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:21 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7637,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:32 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7638,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:09 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7639,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:43 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "athlete_id": 1811,
-                    "rank": 3,
-                    "firstname": "Brooke",
-                    "lastname": "RABOUTOU",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "USA",
-                    "federation_id": 20,
-                    "rounds": [
-                        {
-                            "category_round_id": 6849,
-                            "round_name": "Qualification",
-                            "score": "2T4z 7 8",
-                            "ascents": [
-                                {
-                                    "route_id": 7619,
-                                    "route_name": "1",
-                                    "top": false,
-                                    "top_tries": 11,
-                                    "zone": false,
-                                    "zone_tries": 11,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:34:59 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7620,
-                                    "route_name": "2",
-                                    "top": false,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:35:53 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7621,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:05 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7622,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:27 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7623,
-                                    "route_name": "5",
-                                    "top": true,
-                                    "top_tries": 5,
-                                    "zone": true,
-                                    "zone_tries": 5,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:11 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7424,
-                            "round_name": "Semi-final",
-                            "score": "3T4z 11 10",
-                            "ascents": [
-                                {
-                                    "route_id": 7628,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:51:06 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7629,
-                                    "route_name": "2",
-                                    "top": false,
-                                    "top_tries": 8,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:57:33 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7630,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:08:07 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7631,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 4,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:20:05 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7426,
-                            "round_name": "Final",
-                            "score": "3T3z 6 5",
-                            "ascents": [
-                                {
-                                    "route_id": 7636,
-                                    "route_name": "1",
-                                    "top": false,
-                                    "top_tries": 10,
-                                    "zone": false,
-                                    "zone_tries": 10,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:20 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7637,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:32 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7638,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:09 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7639,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:43 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "athlete_id": 3840,
-                    "rank": 4,
-                    "firstname": "Stasa",
-                    "lastname": "GEJO",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "SRB",
-                    "federation_id": 56,
-                    "rounds": [
-                        {
-                            "category_round_id": 6849,
-                            "round_name": "Qualification",
-                            "score": "5T5z 10 8",
-                            "ascents": [
-                                {
-                                    "route_id": 7619,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:34:53 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7620,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:35:52 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7621,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:08 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7622,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:28 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7623,
-                                    "route_name": "5",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:06 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7424,
-                            "round_name": "Semi-final",
-                            "score": "3T3z 8 7",
-                            "ascents": [
-                                {
-                                    "route_id": 7628,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:51:14 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7629,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:57:41 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7630,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 5,
-                                    "zone": false,
-                                    "zone_tries": 5,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:08:15 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7631,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:20:12 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7426,
-                            "round_name": "Final",
-                            "score": "2T4z 3 13",
-                            "ascents": [
-                                {
-                                    "route_id": 7636,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:21 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7637,
-                                    "route_name": "2",
-                                    "top": false,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 6,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:32 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7638,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:10 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7639,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 5,
-                                    "zone": true,
-                                    "zone_tries": 5,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:44 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "athlete_id": 947,
-                    "rank": 5,
-                    "firstname": "Camilla",
-                    "lastname": "MORONI",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "ITA",
-                    "federation_id": 13,
-                    "rounds": [
-                        {
-                            "category_round_id": 6849,
-                            "round_name": "Qualification",
-                            "score": "4T5z 5 8",
-                            "ascents": [
-                                {
-                                    "route_id": 7619,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:35:58 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7620,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:00 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7621,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 5,
-                                    "zone": true,
-                                    "zone_tries": 4,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:07 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7622,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:29 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7623,
-                                    "route_name": "5",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:36:07 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7424,
-                            "round_name": "Semi-final",
-                            "score": "4T4z 18 15",
-                            "ascents": [
-                                {
-                                    "route_id": 7628,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:51:14 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7629,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 9,
-                                    "zone": true,
-                                    "zone_tries": 8,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:57:40 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7630,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:08:15 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7631,
-                                    "route_name": "4",
-                                    "top": true,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:20:12 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7426,
-                            "round_name": "Final",
-                            "score": "1T2z 6 8",
-                            "ascents": [
-                                {
-                                    "route_id": 7636,
-                                    "route_name": "1",
-                                    "top": false,
-                                    "top_tries": 9,
-                                    "zone": false,
-                                    "zone_tries": 9,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:19 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7637,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 6,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:33 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7638,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:07 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7639,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 7,
-                                    "zone": false,
-                                    "zone_tries": 7,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:42 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "athlete_id": 13321,
-                    "rank": 6,
-                    "firstname": "Mia",
-                    "lastname": "AOYAGI",
-                    "paraclimbing_sport_class": null,
-                    "sport_class_status": null,
-                    "country": "JPN",
-                    "federation_id": 25,
-                    "rounds": [
-                        {
-                            "category_round_id": 6849,
-                            "round_name": "Qualification",
-                            "score": "3T3z 7 6",
-                            "ascents": [
-                                {
-                                    "route_id": 7619,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 1,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:37:12 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7620,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:37:13 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7621,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 4,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:37:24 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7622,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 5,
-                                    "zone": false,
-                                    "zone_tries": 5,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:37:24 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7623,
-                                    "route_name": "5",
-                                    "top": false,
-                                    "top_tries": 5,
-                                    "zone": false,
-                                    "zone_tries": 5,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-07 05:37:30 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7424,
-                            "round_name": "Semi-final",
-                            "score": "3T4z 8 12",
-                            "ascents": [
-                                {
-                                    "route_id": 7628,
-                                    "route_name": "1",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:51:09 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7629,
-                                    "route_name": "2",
-                                    "top": true,
-                                    "top_tries": 2,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 03:57:35 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7630,
-                                    "route_name": "3",
-                                    "top": true,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 3,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:08:11 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7631,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 6,
-                                    "zone": true,
-                                    "zone_tries": 4,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 04:20:08 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        },
-                        {
-                            "category_round_id": 7426,
-                            "round_name": "Final",
-                            "score": "0T3z 0 4",
-                            "ascents": [
-                                {
-                                    "route_id": 7636,
-                                    "route_name": "1",
-                                    "top": false,
-                                    "top_tries": 5,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:20 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7637,
-                                    "route_name": "2",
-                                    "top": false,
-                                    "top_tries": 4,
-                                    "zone": true,
-                                    "zone_tries": 2,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:33 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7638,
-                                    "route_name": "3",
-                                    "top": false,
-                                    "top_tries": 3,
-                                    "zone": true,
-                                    "zone_tries": 1,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:26:08 +00:00",
-                                    "status": "locked"
-                                },
-                                {
-                                    "route_id": 7639,
-                                    "route_name": "4",
-                                    "top": false,
-                                    "top_tries": 8,
-                                    "zone": false,
-                                    "zone_tries": 8,
-                                    "low_zone": null,
-                                    "points": null,
-                                    "low_zone_tries": null,
-                                    "modified": "2022-05-08 09:59:42 +00:00",
-                                    "status": "locked"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+        {
+          "athlete_id": 11462,
+          "rank": 2,
+          "firstname": "Oriane",
+          "lastname": "BERTONE",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "FRA",
+          "federation_id": 10,
+          "rounds": [
+            {
+              "category_round_id": 6849,
+              "round_name": "Qualification",
+              "score": "4T5z 10 7",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7619,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:35:06 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7620,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:35:56 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7621,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:08 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7622,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:38:40 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7623,
+                    "route_name": "5",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:07 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7424,
+              "round_name": "Semi-final",
+              "score": "3T3z 5 5",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7628,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:51:13 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7629,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:57:40 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7630,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 6,
+                    "zone": false,
+                    "zone_tries": 6,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:08:14 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7631,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:20:11 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7426,
+              "round_name": "Final",
+              "score": "3T4z 5 5",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7636,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:21 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7637,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:32 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7638,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:09 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7639,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:43 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "athlete_id": 1811,
+          "rank": 3,
+          "firstname": "Brooke",
+          "lastname": "RABOUTOU",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "USA",
+          "federation_id": 20,
+          "rounds": [
+            {
+              "category_round_id": 6849,
+              "round_name": "Qualification",
+              "score": "2T4z 7 8",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7619,
+                    "route_name": "1",
+                    "top": false,
+                    "top_tries": 11,
+                    "zone": false,
+                    "zone_tries": 11,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:34:59 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7620,
+                    "route_name": "2",
+                    "top": false,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:35:53 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7621,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:05 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7622,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:27 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7623,
+                    "route_name": "5",
+                    "top": true,
+                    "top_tries": 5,
+                    "zone": true,
+                    "zone_tries": 5,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:11 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7424,
+              "round_name": "Semi-final",
+              "score": "3T4z 11 10",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7628,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:51:06 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7629,
+                    "route_name": "2",
+                    "top": false,
+                    "top_tries": 8,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:57:33 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7630,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:08:07 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7631,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 4,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:20:05 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7426,
+              "round_name": "Final",
+              "score": "3T3z 6 5",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7636,
+                    "route_name": "1",
+                    "top": false,
+                    "top_tries": 10,
+                    "zone": false,
+                    "zone_tries": 10,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:20 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7637,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:32 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7638,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:09 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7639,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:43 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "athlete_id": 3840,
+          "rank": 4,
+          "firstname": "Stasa",
+          "lastname": "GEJO",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "SRB",
+          "federation_id": 56,
+          "rounds": [
+            {
+              "category_round_id": 6849,
+              "round_name": "Qualification",
+              "score": "5T5z 10 8",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7619,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:34:53 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7620,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:35:52 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7621,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:08 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7622,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:28 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7623,
+                    "route_name": "5",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:06 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7424,
+              "round_name": "Semi-final",
+              "score": "3T3z 8 7",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7628,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:51:14 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7629,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:57:41 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7630,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 5,
+                    "zone": false,
+                    "zone_tries": 5,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:08:15 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7631,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:20:12 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7426,
+              "round_name": "Final",
+              "score": "2T4z 3 13",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7636,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:21 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7637,
+                    "route_name": "2",
+                    "top": false,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 6,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:32 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7638,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:10 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7639,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 5,
+                    "zone": true,
+                    "zone_tries": 5,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:44 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "athlete_id": 947,
+          "rank": 5,
+          "firstname": "Camilla",
+          "lastname": "MORONI",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "ITA",
+          "federation_id": 13,
+          "rounds": [
+            {
+              "category_round_id": 6849,
+              "round_name": "Qualification",
+              "score": "4T5z 5 8",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7619,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:35:58 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7620,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:00 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7621,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 5,
+                    "zone": true,
+                    "zone_tries": 4,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:07 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7622,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:29 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7623,
+                    "route_name": "5",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:36:07 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7424,
+              "round_name": "Semi-final",
+              "score": "4T4z 18 15",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7628,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:51:14 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7629,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 9,
+                    "zone": true,
+                    "zone_tries": 8,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:57:40 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7630,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:08:15 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7631,
+                    "route_name": "4",
+                    "top": true,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:20:12 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7426,
+              "round_name": "Final",
+              "score": "1T2z 6 8",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7636,
+                    "route_name": "1",
+                    "top": false,
+                    "top_tries": 9,
+                    "zone": false,
+                    "zone_tries": 9,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:19 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7637,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 6,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:33 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7638,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:07 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7639,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 7,
+                    "zone": false,
+                    "zone_tries": 7,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:42 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "athlete_id": 13321,
+          "rank": 6,
+          "firstname": "Mia",
+          "lastname": "AOYAGI",
+          "paraclimbing_sport_class": null,
+          "sport_class_status": null,
+          "country": "JPN",
+          "federation_id": 25,
+          "rounds": [
+            {
+              "category_round_id": 6849,
+              "round_name": "Qualification",
+              "score": "3T3z 7 6",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7619,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 1,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:37:12 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7620,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:37:13 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7621,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 4,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:37:24 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7622,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 5,
+                    "zone": false,
+                    "zone_tries": 5,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:37:24 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7623,
+                    "route_name": "5",
+                    "top": false,
+                    "top_tries": 5,
+                    "zone": false,
+                    "zone_tries": 5,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-07 05:37:30 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7424,
+              "round_name": "Semi-final",
+              "score": "3T4z 8 12",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7628,
+                    "route_name": "1",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:51:09 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7629,
+                    "route_name": "2",
+                    "top": true,
+                    "top_tries": 2,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 03:57:35 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7630,
+                    "route_name": "3",
+                    "top": true,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 3,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:08:11 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7631,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 6,
+                    "zone": true,
+                    "zone_tries": 4,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 04:20:08 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            },
+            {
+              "category_round_id": 7426,
+              "round_name": "Final",
+              "score": "0T3z 0 4",
+              "speed_elimination_stages": {
+                "ascents": [
+                  {
+                    "route_id": 7636,
+                    "route_name": "1",
+                    "top": false,
+                    "top_tries": 5,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:20 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7637,
+                    "route_name": "2",
+                    "top": false,
+                    "top_tries": 4,
+                    "zone": true,
+                    "zone_tries": 2,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:33 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7638,
+                    "route_name": "3",
+                    "top": false,
+                    "top_tries": 3,
+                    "zone": true,
+                    "zone_tries": 1,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:26:08 +00:00",
+                    "status": "locked"
+                  },
+                  {
+                    "route_id": 7639,
+                    "route_name": "4",
+                    "top": false,
+                    "top_tries": 8,
+                    "zone": false,
+                    "zone_tries": 8,
+                    "low_zone": null,
+                    "points": null,
+                    "low_zone_tries": null,
+                    "modified": "2022-05-08 09:59:42 +00:00",
+                    "status": "locked"
+                  }
+                ]
+              }
+            }
+          ]
         }
+      ]
     }
+  }
 }

--- a/wiremock-mappings/eventResults.json
+++ b/wiremock-mappings/eventResults.json
@@ -9,6 +9,7 @@
             "Content-Type": "application/json"
         },
         "jsonBody": {
+            "name": "IFSC World Cup championships of the moon",
             "d_cats": [
                 {
                     "discipline_kind": "boulder",

--- a/wiremock-mappings/seasonLeagueResults.json
+++ b/wiremock-mappings/seasonLeagueResults.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "url": "/results-api.php?api=season_league_results&league=1234"
+        "url": "/results-api.php?api=season_leagues_results&league=1234"
     },
     "response": {
         "status": 200,


### PR DESCRIPTION
I tested this from 2006 through 2022 and updated models accordingly. Mostly the differences come down to where `ascents` live in the response and some nullability I didn't expect. But that's a good time range! Before 2006 there's some weird stuff in the responses, like look at these [weird html warnings at the beginning of the repsonse body](https://components.ifsc-climbing.org/results-api.php?api=event_results&event_id=390).

Closes #2 